### PR TITLE
party config

### DIFF
--- a/online_party_system/party.go
+++ b/online_party_system/party.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/heroiclabs/nakama-common/runtime"
 )
 
@@ -26,7 +27,12 @@ const (
 )
 
 // Registers the collection of functions with Nakama required to provide an OnlinePartyService from Unreal Engine.
-func Register(initializer runtime.Initializer) error {
+func Register(initializer runtime.Initializer, config PartyConfig) error {
+	createPartyMatch := func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) (runtime.Match, error) {
+		return &PartyMatch{
+			config: config,
+		}, nil
+	}
 	if err := initializer.RegisterMatch(fmt.Sprintf("%s-%s", serviceName, "Party"), createPartyMatch); err != nil {
 		return err
 	}
@@ -37,8 +43,4 @@ func Register(initializer runtime.Initializer) error {
 		return err
 	}
 	return nil
-}
-
-func createPartyMatch(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) (runtime.Match, error) {
-	return &PartyMatch{}, nil
 }

--- a/online_party_system/party_rpc.go
+++ b/online_party_system/party_rpc.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+
 	"github.com/heroiclabs/nakama-common/runtime"
 )
 
@@ -161,7 +162,7 @@ func rpcGetAdvertisedParty(ctx context.Context, logger runtime.Logger, db *sql.D
 
 	// List matches looking for the appropriate one.
 	query := fmt.Sprintf("+label.type_id:%v +label.members:%v", request.PartyTypeId, request.UserId)
-	matches, err := nk.MatchList(ctx, 1, true, "", 0, 0, query)
+	matches, err := nk.MatchList(ctx, 1, true, "", 0, 999, query)
 	if err != nil {
 		logger.Error("match list failed: %v", err)
 		return "", ErrBadContext


### PR DESCRIPTION
party config
"fix" match list bug in rpcGetAdvertisedParty by listing 999 matches instead of 0. This is a workaround fix that should be reverted when matchList is using *int rather than int type
add presence as sender in OpCodeGetPartyMemberData broadcasts so receiver can tell whose party member data they are getting