### PR TITLE
feat: add party config to match label

### DIFF
--- a/online_party_system/party_match.go
+++ b/online_party_system/party_match.go
@@ -79,6 +79,7 @@ type PartyMatchLabel struct {
 	OnlinePartyTypeId int64                        `json:"type_id,omitempty"`
 	Members           []string                     `json:"members,omitempty"`
 	Metadata          map[string]map[string]string `json:"metadata,omitempty"`
+	Config            string                       `json:"config,omitempty"`
 }
 
 type PartyMatchState struct {
@@ -154,7 +155,7 @@ func (p *PartyMatch) MatchInit(ctx context.Context, logger runtime.Logger, db *s
 		logger.Error("Error creating party, no type_id in params")
 		return nil, 0, ""
 	}
-	_, ok = params["config"].(string)
+	config, ok := params["config"].(string)
 	if !ok {
 		logger.Error("Error creating party, no config in params")
 		return nil, 0, ""
@@ -163,6 +164,7 @@ func (p *PartyMatch) MatchInit(ctx context.Context, logger runtime.Logger, db *s
 	label := &PartyMatchLabel{
 		OnlinePartyTypeId: typeId,
 		Members:           make([]string, 0, 5),
+		Config:            config,
 	}
 	labelBytes, err := json.Marshal(label)
 	if err != nil {


### PR DESCRIPTION
During party creation, store party config in the match label so that it
is easily searchable and available when getting/listing parties.