### PR TITLE
adding leave and kick hooks, firing end hook when match leave returns nil

### DIFF
--- a/online_party_system/party.go
+++ b/online_party_system/party.go
@@ -37,22 +37,28 @@ type MatchInitHook func(matchID string, config PartyConfig, label *PartyMatchLab
 
 type MatchJoinAttemptHook func(matchID string, presence runtime.Presence, meta map[string]string) (bool, string)
 
+type MatchLeaveHook func(matchID string, userId string)
+
+type MatchKickHook func(matchID string, userId string)
+
 func noopMatchJoinMetadataFilter(metadata map[string]string) map[string]string {
 	return metadata
 }
 
 // Registers the collection of functions with Nakama required to provide an OnlinePartyService from Unreal Engine.
-func Register(initializer runtime.Initializer, config PartyConfig, matchJoinMetadataFilter MatchJoinMetadataFilter, matchTerminateHook MatchEndHook, matchInitHook MatchInitHook, matchJoinAttemptHook MatchJoinAttemptHook) error {
+func Register(initializer runtime.Initializer, config PartyConfig, matchJoinMetadataFilter MatchJoinMetadataFilter, matchTerminateHook MatchEndHook, matchInitHook MatchInitHook, matchJoinAttemptHook MatchJoinAttemptHook, matchLeaveHook MatchLeaveHook, matchKickHook MatchKickHook) error {
 	if matchJoinMetadataFilter == nil {
 		matchJoinMetadataFilter = noopMatchJoinMetadataFilter
 	}
 	createPartyMatch := func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) (runtime.Match, error) {
 		return &PartyMatch{
-			config:                  config,
-			matchJoinMetadataFilter: matchJoinMetadataFilter,
-			matchEndHook:            matchTerminateHook,
-			matchInitHook:           matchInitHook,
-			matchJoinAttemptHook:    matchJoinAttemptHook,
+			config:                  	config,
+			matchJoinMetadataFilter: 	matchJoinMetadataFilter,
+			matchEndHook:            	matchTerminateHook,
+			matchInitHook:           	matchInitHook,
+			matchJoinAttemptHook:    	matchJoinAttemptHook,
+			matchLeaveHook:    			matchLeaveHook,
+			matchKickHook:    			matchKickHook,
 		}, nil
 	}
 

--- a/online_party_system/party.go
+++ b/online_party_system/party.go
@@ -46,19 +46,13 @@ func noopMatchJoinMetadataFilter(metadata map[string]string) map[string]string {
 }
 
 // Registers the collection of functions with Nakama required to provide an OnlinePartyService from Unreal Engine.
-func Register(initializer runtime.Initializer, config PartyConfig, matchJoinMetadataFilter MatchJoinMetadataFilter, matchTerminateHook MatchEndHook, matchInitHook MatchInitHook, matchJoinAttemptHook MatchJoinAttemptHook, matchLeaveHook MatchLeaveHook, matchKickHook MatchKickHook) error {
-	if matchJoinMetadataFilter == nil {
-		matchJoinMetadataFilter = noopMatchJoinMetadataFilter
+func Register(initializer runtime.Initializer, config PartyConfig) error {
+	if config.MatchJoinMetadataFilter == nil {
+		config.MatchJoinMetadataFilter = noopMatchJoinMetadataFilter
 	}
 	createPartyMatch := func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule) (runtime.Match, error) {
 		return &PartyMatch{
-			config:                  	config,
-			matchJoinMetadataFilter: 	matchJoinMetadataFilter,
-			matchEndHook:            	matchTerminateHook,
-			matchInitHook:           	matchInitHook,
-			matchJoinAttemptHook:    	matchJoinAttemptHook,
-			matchLeaveHook:    			matchLeaveHook,
-			matchKickHook:    			matchKickHook,
+			config: config,
 		}, nil
 	}
 


### PR DESCRIPTION
I'm not sure if you want to accept changes to the nkcommon13 branch, but we needed to make some changes to add/fix party hooks.

A couple Qs:

Should we move all the hooks (and potentially other stuff passed into Register) into PartyConfig so we're not breaking the API every time we add/remove hooks going forward?

It would be good to pick either "MatchTerminateHook" or "MatchEndHook" for the hook name and get rid of the other. I'm happy to add that change, but figured might as well answer the above question about PartyConfig first.

The MatchEndHook was not firing when the match ended due to the last user leaving. Was that intentional? I've added the callback into MatchLeave() to fix.