### PR TITLE
fixed FNakamaStoreObjectAck constructor - copy version to ack

### DIFF
--- a/Nakama/Source/NakamaUnreal/Private/NakamaStorageObject.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaStorageObject.cpp
@@ -65,6 +65,7 @@ FNakamaDeleteStorageObjectId::FNakamaDeleteStorageObjectId()
 FNakamaStoreObjectAck::FNakamaStoreObjectAck(const NStorageObjectAck& NakamaNativeStorageObjectAck)
 	: Collection(FNakamaUtils::StdStringToUEString(NakamaNativeStorageObjectAck.collection))
 	, Key(FNakamaUtils::StdStringToUEString(NakamaNativeStorageObjectAck.key))
+	, Version(FNakamaUtils::StdStringToUEString(NakamaNativeStorageObjectAck.version))
 	, UserId(FNakamaUtils::StdStringToUEString(NakamaNativeStorageObjectAck.userId))
 {
 	


### PR DESCRIPTION
Write objects via REST API returns versions. API in Unreal doesn't do this. Looks like the wrong constructor.