### PR TITLE
fixed warning - Initialize of FNakamaChatMessage::MessageType

### DIFF
--- a/Nakama/Source/NakamaUnreal/Public/NakamaChat.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaChat.h
@@ -22,7 +22,7 @@ struct NAKAMAUNREAL_API FNakamaChatMessage
 
 	// The Message Type.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Nakama Chat")
-	ENakamaChannelType MessageType;
+	ENakamaChannelType MessageType = ENakamaChannelType::TYPE_UNSPECIFIED;
 
 	// Group Name to Send To.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Nakama Chat")


### PR DESCRIPTION
When we build Unreal on Windows, we always get a warning:
**LogClass: Error: EnumProperty FNakamaChatMessage::MessageType is not initialized properly. Module:NakamaUnreal File:Public/NakamaChat.h**

This fixes this.