### PR TITLE
fix deserialization of StatusPresenceEvent

### DIFF
--- a/Nakama/Source/NakamaUnreal/Private/NakamaStatus.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaStatus.cpp
@@ -74,7 +74,7 @@ FNakamaStatusPresenceEvent::FNakamaStatusPresenceEvent(const FString& JsonString
 					{
 						Writer->Close();
 						FNakamaUserPresence User(UserPresenceJsonString);
-						Joins.Add(User);
+						Leaves.Add(User);
 					}
 				}
 			}


### PR DESCRIPTION
The deserialization in the constructor of FNakamaStatusPresenceEvent added all statuses into Joins (as new statuses).
The array Leaves was always empty.