### PR TITLE
Remove unnecessary serialization and add get flag satori api.

### DIFF
--- a/Nakama/Source/NakamaUnreal/Private/NakamaAccount.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaAccount.cpp
@@ -3,7 +3,6 @@
 
 FNakamaAccount::FNakamaAccount(): VerifyTime(FDateTime::MinValue()), DisableTime(FDateTime::MinValue())
 {
-	
 }
 
 FNakamaAccount::FNakamaAccount(const FString& JsonString)
@@ -16,17 +15,11 @@ FNakamaAccount::FNakamaAccount(const FString& JsonString)
         return;
     }
 	
-	if (JsonObject->HasTypedField<EJson::Object>(TEXT("user")))
-	{
-		TSharedPtr<FJsonObject> UserJsonObject = JsonObject->GetObjectField(TEXT("user"));
 
-		FString UserJsonString;
-		auto Writer = TJsonWriterFactory<>::Create(&UserJsonString);
-		if (FJsonSerializer::Serialize(UserJsonObject.ToSharedRef(), Writer))
-		{
-			Writer->Close();
-			User = FNakamaUser(UserJsonString);
-		}
+	const TSharedPtr<FJsonObject>* UserJsonObject;
+	if (JsonObject->TryGetObjectField(TEXT("user"), UserJsonObject))
+	{
+		User = FNakamaUser(*UserJsonObject);
 	}
 
     JsonObject->TryGetStringField(TEXT("wallet"), Wallet);
@@ -40,18 +33,10 @@ FNakamaAccount::FNakamaAccount(const FString& JsonString)
     	{
     		for (const TSharedPtr<FJsonValue>& DeviceJson : *DevicesJsonArray)
     		{
-    			if (DeviceJson->Type == EJson::Object)
+    			if (TSharedPtr<FJsonObject> DeviceJsonObject = DeviceJson->AsObject())
     			{
-    				TSharedPtr<FJsonObject> DeviceJsonObject = DeviceJson->AsObject();
-                
-    				FString DeviceJsonString;
-    				auto Writer = TJsonWriterFactory<>::Create(&DeviceJsonString);
-    				if (FJsonSerializer::Serialize(DeviceJsonObject.ToSharedRef(), Writer))
-    				{
-    					Writer->Close();
-    					FNakamaAccountDevice Device(DeviceJsonString);
-    					Devices.Add(Device);
-    				}
+    				FNakamaAccountDevice Device(DeviceJsonObject);
+    				Devices.Add(Device);
     			}
     		}
     	}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaAccountDevice.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaAccountDevice.cpp
@@ -1,13 +1,13 @@
-﻿#include "NakamaAccountDevice.h"
+#include "NakamaAccountDevice.h"
 
 #include "NakamaUtils.h"
 
-FNakamaAccountDevice::FNakamaAccountDevice(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(JsonString);
+FNakamaAccountDevice::FNakamaAccountDevice(const FString& JsonString) : FNakamaAccountDevice(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaAccountDevice::FNakamaAccountDevice(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		if (JsonObject->HasField(TEXT("id")))
 		{

--- a/Nakama/Source/NakamaUnreal/Private/NakamaChannelTypes.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaChannelTypes.cpp
@@ -1,12 +1,12 @@
 #include "NakamaChannelTypes.h"
 #include "NakamaUtils.h"
 
-FNakamaChannelMessage::FNakamaChannelMessage(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaChannelMessage::FNakamaChannelMessage(const FString& JsonString) : FNakamaChannelMessage(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaChannelMessage::FNakamaChannelMessage(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("channel_id"), ChannelId);
 		JsonObject->TryGetStringField(TEXT("message_id"), MessageId);
@@ -86,19 +86,10 @@ FNakamaChannelMessageList::FNakamaChannelMessageList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& MessageJsonValue : *MessagesJsonArray)
 			{
-				if (MessageJsonValue->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> MessageJsonObject = MessageJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> MessageJsonObject = MessageJsonValue->AsObject();
-					if (MessageJsonObject.IsValid())
-					{
-						FString MessageJsonString;
-						TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&MessageJsonString);
-						if (FJsonSerializer::Serialize(MessageJsonObject.ToSharedRef(), JsonWriter))
-						{
-							FNakamaChannelMessage Message(MessageJsonString);
-							Messages.Add(Message);
-						}
-					}
+					FNakamaChannelMessage Message(MessageJsonObject);
+					Messages.Add(Message);
 				}
 			}
 		}
@@ -128,20 +119,10 @@ FNakamaChannelPresenceEvent::FNakamaChannelPresenceEvent(const FString& JsonStri
 	    {
 	        for (const TSharedPtr<FJsonValue>& JoinJsonValue : *JoinsJsonArray)
 	        {
-	            if (JoinJsonValue->Type == EJson::Object)
+	            if (TSharedPtr<FJsonObject> JoinJsonObject = JoinJsonValue->AsObject())
 	            {
-	                TSharedPtr<FJsonObject> JoinJsonObject = JoinJsonValue->AsObject();
-	                if (JoinJsonObject.IsValid())
-	                {
-	                    FString JoinPresenceJsonString;
-	                    TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&JoinPresenceJsonString);
-	                    if (FJsonSerializer::Serialize(JoinJsonObject.ToSharedRef(), JsonWriter))
-	                    {
-	                        JsonWriter->Close();
-	                        FNakamaUserPresence JoinPresence(JoinPresenceJsonString);
-	                        Joins.Add(JoinPresence);
-	                    }
-	                }
+	                FNakamaUserPresence JoinPresence(JoinJsonObject);
+	                Joins.Add(JoinPresence);
 	            }
 	        }
 	    }
@@ -151,20 +132,10 @@ FNakamaChannelPresenceEvent::FNakamaChannelPresenceEvent(const FString& JsonStri
 	    {
 	        for (const TSharedPtr<FJsonValue>& LeaveJsonValue : *LeavesJsonArray)
 	        {
-	            if (LeaveJsonValue->Type == EJson::Object)
+	            if (TSharedPtr<FJsonObject> LeaveJsonObject = LeaveJsonValue->AsObject())
 	            {
-	                TSharedPtr<FJsonObject> LeaveJsonObject = LeaveJsonValue->AsObject();
-	                if (LeaveJsonObject.IsValid())
-	                {
-	                    FString LeavePresenceJsonString;
-	                    TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&LeavePresenceJsonString);
-	                    if (FJsonSerializer::Serialize(LeaveJsonObject.ToSharedRef(), JsonWriter))
-	                    {
-	                        JsonWriter->Close();
-	                        FNakamaUserPresence LeavePresence(LeavePresenceJsonString);
-	                        Leaves.Add(LeavePresence);
-	                    }
-	                }
+	                FNakamaUserPresence LeavePresence(LeaveJsonObject);
+	                Leaves.Add(LeavePresence);
 	            }
 	        }
 	    }

--- a/Nakama/Source/NakamaUnreal/Private/NakamaChat.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaChat.cpp
@@ -1,4 +1,4 @@
-﻿#include "NakamaChat.h"
+#include "NakamaChat.h"
 
 FNakamaChannel::FNakamaChannel()
 {
@@ -28,18 +28,10 @@ FNakamaChannel::FNakamaChannel(const FString& JsonString)
 			{
 				for (const TSharedPtr<FJsonValue>& PresenceJsonValue : *PresencesJsonArray)
 				{
-					if (PresenceJsonValue->Type == EJson::Object)
+					if (TSharedPtr<FJsonObject> PresenceJsonObject = PresenceJsonValue->AsObject())
 					{
-						TSharedPtr<FJsonObject> PresenceJsonObject = PresenceJsonValue->AsObject();
-
-						FString PresenceJsonString;
-						auto Writer = TJsonWriterFactory<>::Create(&PresenceJsonString);
-						if (FJsonSerializer::Serialize(PresenceJsonObject.ToSharedRef(), Writer))
-						{
-							Writer->Close();
-							FNakamaUserPresence Presence(PresenceJsonString);
-							Presences.Add(Presence);
-						}
+						FNakamaUserPresence Presence(PresenceJsonObject);
+						Presences.Add(Presence);
 					}
 				}
 			}
@@ -47,15 +39,7 @@ FNakamaChannel::FNakamaChannel(const FString& JsonString)
 			const TSharedPtr<FJsonObject>* SelfObjectPtr;
 			if (ChannelObject->TryGetObjectField(TEXT("self"), SelfObjectPtr))
 			{
-				TSharedPtr<FJsonObject> SelfObject = *SelfObjectPtr;
-				
-				FString SelfJsonString;
-				auto Writer = TJsonWriterFactory<>::Create(&SelfJsonString);
-				if (FJsonSerializer::Serialize(SelfObject.ToSharedRef(), Writer))
-				{
-					Writer->Close();
-					Me = FNakamaUserPresence(SelfJsonString);
-				}
+				Me = FNakamaUserPresence(*SelfObjectPtr);
 			}
 		}
 	}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaLeaderboard.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaLeaderboard.cpp
@@ -1,13 +1,12 @@
-﻿#include "NakamaLeaderboard.h"
-
+#include "NakamaLeaderboard.h"
 #include "NakamaUtils.h"
 
-FNakamaLeaderboardRecord::FNakamaLeaderboardRecord(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaLeaderboardRecord::FNakamaLeaderboardRecord(const FString& JsonString) : FNakamaLeaderboardRecord(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaLeaderboardRecord::FNakamaLeaderboardRecord(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("leaderboard_id"), LeaderboardId);
 		JsonObject->TryGetStringField(TEXT("owner_id"), OwnerId);
@@ -57,19 +56,10 @@ FNakamaLeaderboardRecordList::FNakamaLeaderboardRecordList(const FString& JsonSt
         {
             for (const TSharedPtr<FJsonValue>& RecordJsonValue : *RecordsJsonArray)
             {
-                if (RecordJsonValue->Type == EJson::Object)
-                {
-                    TSharedPtr<FJsonObject> RecordJsonObject = RecordJsonValue->AsObject();
-
-                    FString RecordJsonString;
-                    auto Writer = TJsonWriterFactory<>::Create(&RecordJsonString);
-                    if (FJsonSerializer::Serialize(RecordJsonObject.ToSharedRef(), Writer))
-                    {
-                        Writer->Close();
-                        FNakamaLeaderboardRecord Record(RecordJsonString);
-                        Records.Add(Record);
-                    }
-                }
+                if (TSharedPtr<FJsonObject> RecordJsonObject = RecordJsonValue->AsObject())
+				{
+					Records.Add(FNakamaLeaderboardRecord(RecordJsonObject));
+				}
             }
         }
 
@@ -78,19 +68,10 @@ FNakamaLeaderboardRecordList::FNakamaLeaderboardRecordList(const FString& JsonSt
         {
             for (const TSharedPtr<FJsonValue>& OwnerRecordJsonValue : *OwnerRecordsJsonArray)
             {
-                if (OwnerRecordJsonValue->Type == EJson::Object)
-                {
-                    TSharedPtr<FJsonObject> OwnerRecordJsonObject = OwnerRecordJsonValue->AsObject();
-
-                    FString OwnerRecordJsonString;
-                    auto Writer = TJsonWriterFactory<>::Create(&OwnerRecordJsonString);
-                    if (FJsonSerializer::Serialize(OwnerRecordJsonObject.ToSharedRef(), Writer))
-                    {
-                        Writer->Close();
-                        FNakamaLeaderboardRecord OwnerRecord(OwnerRecordJsonString);
-                        OwnerRecords.Add(OwnerRecord);
-                    }
-                }
+				if (TSharedPtr<FJsonObject> OwnerRecordJsonObject = OwnerRecordJsonValue->AsObject())
+				{
+					OwnerRecords.Add(FNakamaLeaderboardRecord(OwnerRecordJsonObject));
+				}
             }
         }
 

--- a/Nakama/Source/NakamaUnreal/Private/NakamaMatch.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaMatch.cpp
@@ -1,67 +1,47 @@
 #include "NakamaMatch.h"
 #include "NakamaUtils.h"
 
-FNakamaMatch::FNakamaMatch(const FString& JsonString)
+FNakamaMatch::FNakamaMatch(const FString& JsonString) : FNakamaMatch(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
+
+FNakamaMatch::FNakamaMatch(const TSharedPtr<FJsonObject> JsonObject)
 {
-	// Parse the JSON string
-    TSharedPtr<FJsonObject> JsonObject;
-    TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-    if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-    {
-        return;
-    }
+	if (JsonObject.IsValid())
+	{
+		// Try to get the "match" object from the parsed JSON
+		const TSharedPtr<FJsonObject>* MatchObjectPtr = nullptr;
+		JsonObject->TryGetObjectField(TEXT("match"), MatchObjectPtr);
 
-    // Try to get the "match" object from the parsed JSON
-    const TSharedPtr<FJsonObject>* MatchObjectPtr = nullptr;
-    JsonObject->TryGetObjectField(TEXT("match"), MatchObjectPtr);
-    
-    // If "match" object is not found, use the root object
-    TSharedPtr<FJsonObject> MatchObject = MatchObjectPtr ? *MatchObjectPtr : JsonObject;
+		// If "match" object is not found, use the root object
+		TSharedPtr<FJsonObject> MatchObject = MatchObjectPtr ? *MatchObjectPtr : JsonObject;
 
-	// NOTE: Server can respond with 'tick_rate' and 'handler_name' as well
+		// NOTE: Server can respond with 'tick_rate' and 'handler_name' as well
 
-    // Extract and assign the individual fields
-    MatchObject->TryGetStringField(TEXT("match_id"), MatchId);
-    MatchObject->TryGetBoolField(TEXT("authoritative"), Authoritative);
-    MatchObject->TryGetStringField(TEXT("label"), Label);
-    MatchObject->TryGetNumberField(TEXT("size"), Size);
+		// Extract and assign the individual fields
+		MatchObject->TryGetStringField(TEXT("match_id"), MatchId);
+		MatchObject->TryGetBoolField(TEXT("authoritative"), Authoritative);
+		MatchObject->TryGetStringField(TEXT("label"), Label);
+		MatchObject->TryGetNumberField(TEXT("size"), Size);
 
-    const TArray<TSharedPtr<FJsonValue>>* JoinsJsonArray;
-    if (MatchObject->TryGetArrayField(TEXT("presences"), JoinsJsonArray))
-    {
-        for (const TSharedPtr<FJsonValue>& UserPresence : *JoinsJsonArray)
-        {
-            if (UserPresence->Type == EJson::Object)
-            {
-                TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject();
-                FString UserPresenceJsonString;
-                auto Writer = TJsonWriterFactory<>::Create(&UserPresenceJsonString);
-                if (FJsonSerializer::Serialize(UserPresenceJsonObject.ToSharedRef(), Writer))
-                {
-                    Writer->Close();
-                    FNakamaUserPresence User(UserPresenceJsonString);
-                    Pressences.Add(User);
-                }
-            }
-        }
-    }
+		const TArray<TSharedPtr<FJsonValue>>* JoinsJsonArray;
+		if (MatchObject->TryGetArrayField(TEXT("presences"), JoinsJsonArray))
+		{
+			for (const TSharedPtr<FJsonValue>& UserPresence : *JoinsJsonArray)
+			{
+				if (TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject())
+				{
+					Pressences.Add(FNakamaUserPresence(UserPresenceJsonObject));
+				}
+			}
+		}
 
-    // Try to get the "self" object from the match object
-    const TSharedPtr<FJsonObject>* SelfObjectPtr = nullptr;
-    MatchObject->TryGetObjectField(TEXT("self"), SelfObjectPtr);
-    
-    if (SelfObjectPtr)
-    {
-        FString UserPresenceJsonString;
-        auto Writer = TJsonWriterFactory<>::Create(&UserPresenceJsonString);
-        if (FJsonSerializer::Serialize(SelfObjectPtr->ToSharedRef(), Writer))
-        {
-            Writer->Close();
-            FNakamaUserPresence User(UserPresenceJsonString);
-            Me = User;
-        }
-    }
-	
+		// Try to get the "self" object from the match object
+		const TSharedPtr<FJsonObject>* SelfObjectPtr;
+		if (MatchObject->TryGetObjectField(TEXT("self"), SelfObjectPtr))
+		{
+			Me = FNakamaUserPresence(*SelfObjectPtr);
+		}
+	}
 }
 
 FNakamaMatchData::FNakamaMatchData(const FString& JsonString)
@@ -76,13 +56,7 @@ FNakamaMatchData::FNakamaMatchData(const FString& JsonString)
 		const TSharedPtr<FJsonObject>* PresenceJsonObject;
 		if (JsonObject->TryGetObjectField(TEXT("presence"), PresenceJsonObject))
 		{
-			FString PresenceJsonString;
-			auto Writer = TJsonWriterFactory<>::Create(&PresenceJsonString);
-			if (FJsonSerializer::Serialize(PresenceJsonObject->ToSharedRef(), Writer))
-			{
-				Writer->Close();
-				Presence = FNakamaUserPresence(PresenceJsonString);
-			}
+			Presence = FNakamaUserPresence(*PresenceJsonObject);
 		}
 
 		JsonObject->TryGetNumberField(TEXT("op_code"), OpCode);
@@ -111,17 +85,9 @@ FNakamaMatchList::FNakamaMatchList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& MatchJsonValue : *MatchesJsonArray)
 			{
-				if (MatchJsonValue->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> MatchJsonObject = MatchJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> MatchJsonObject = MatchJsonValue->AsObject();
-					FString MatchJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&MatchJsonString);
-					if (FJsonSerializer::Serialize(MatchJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaMatch Match(MatchJsonString);
-						Matches.Add(Match);
-					}
+					Matches.Add(FNakamaMatch(MatchJsonObject));
 				}
 			}
 		}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaNotification.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaNotification.cpp
@@ -1,14 +1,12 @@
-﻿#include "NakamaNotification.h"
-
+#include "NakamaNotification.h"
 #include "NakamaUtils.h"
 
+FNakamaNotification::FNakamaNotification(const FString& JsonString) : FNakamaNotification(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-FNakamaNotification::FNakamaNotification(const FString& JsonString)
+FNakamaNotification::FNakamaNotification(const TSharedPtr<FJsonObject> JsonObject)
 {
-	TSharedPtr<FJsonObject> JsonObject;
-	TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("id"), Id);
 		JsonObject->TryGetStringField(TEXT("subject"), Subject);
@@ -43,17 +41,9 @@ FNakamaNotificationList::FNakamaNotificationList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& NotificationJson : *NotificationsJsonArray)
 			{
-				if (NotificationJson->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> NotificationJsonObject = NotificationJson->AsObject())
 				{
-					TSharedPtr<FJsonObject> NotificationJsonObject = NotificationJson->AsObject();
-					FString NotificationJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&NotificationJsonString);
-					if (FJsonSerializer::Serialize(NotificationJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaNotification Notification(NotificationJsonString);
-						Notifications.Add(Notification);
-					}
+					Notifications.Add(FNakamaNotification(NotificationJsonObject));
 				}
 			}
 		}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaPresence.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaPresence.cpp
@@ -1,13 +1,12 @@
-﻿#include "NakamaPresence.h"
-
+#include "NakamaPresence.h"
 #include "NakamaUtils.h"
 
-FNakamaUserPresence::FNakamaUserPresence(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaUserPresence::FNakamaUserPresence(const FString& JsonString) : FNakamaUserPresence(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaUserPresence::FNakamaUserPresence(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("user_id"), UserID);
 		JsonObject->TryGetStringField(TEXT("session_id"), SessionID);

--- a/Nakama/Source/NakamaUnreal/Private/NakamaStatus.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaStatus.cpp
@@ -1,4 +1,4 @@
-﻿#include "NakamaStatus.h"
+#include "NakamaStatus.h"
 
 #include "NakamaUtils.h"
 #include "NakamaAccount.h"
@@ -18,18 +18,9 @@ FNakamaStatus::FNakamaStatus(const FString& JsonString)
 			{
 				for (const TSharedPtr<FJsonValue>& PresenceJson : *PresencesJsonArray)
 				{
-					if (PresenceJson->Type == EJson::Object)
+					if (TSharedPtr<FJsonObject> PresenceJsonObject = PresenceJson->AsObject())
 					{
-						TSharedPtr<FJsonObject> PresenceJsonObject = PresenceJson->AsObject();
-
-						FString PresenceJsonString;
-						auto Writer = TJsonWriterFactory<>::Create(&PresenceJsonString);
-						if (FJsonSerializer::Serialize(PresenceJsonObject.ToSharedRef(), Writer))
-						{
-							Writer->Close();
-							FNakamaUserPresence Presence(PresenceJsonString);
-							Presences.Add(Presence);
-						}
+						Presences.Add(FNakamaUserPresence(PresenceJsonObject));
 					}
 				}
 			}
@@ -54,18 +45,9 @@ FNakamaStatusPresenceEvent::FNakamaStatusPresenceEvent(const FString& JsonString
 		{
 			for (const TSharedPtr<FJsonValue>& UserPresence : *JoinsJsonArray)
 			{
-				if (UserPresence->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject())
 				{
-					TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject();
-
-					FString UserPresenceJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&UserPresenceJsonString);
-					if (FJsonSerializer::Serialize(UserPresenceJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaUserPresence User(UserPresenceJsonString);
-						Joins.Add(User);
-					}
+					Joins.Add(FNakamaUserPresence(UserPresenceJsonObject));
 				}
 			}
 		}
@@ -75,18 +57,9 @@ FNakamaStatusPresenceEvent::FNakamaStatusPresenceEvent(const FString& JsonString
 		{
 			for (const TSharedPtr<FJsonValue>& UserPresence : *LeavesJsonArray)
 			{
-				if (UserPresence->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject())
 				{
-					TSharedPtr<FJsonObject> UserPresenceJsonObject = UserPresence->AsObject();
-
-					FString UserPresenceJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&UserPresenceJsonString);
-					if (FJsonSerializer::Serialize(UserPresenceJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaUserPresence User(UserPresenceJsonString);
-						Leaves.Add(User);
-					}
+					Leaves.Add(FNakamaUserPresence(UserPresenceJsonObject));
 				}
 			}
 		}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaStorageObject.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaStorageObject.cpp
@@ -1,13 +1,12 @@
-﻿#include "NakamaStorageObject.h"
-
+#include "NakamaStorageObject.h"
 #include "NakamaUtils.h"
 
-FNakamaStoreObjectData::FNakamaStoreObjectData(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaStoreObjectData::FNakamaStoreObjectData(const FString& JsonString) : FNakamaStoreObjectData(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaStoreObjectData::FNakamaStoreObjectData(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("collection"), Collection);
 		JsonObject->TryGetStringField(TEXT("key"), Key);
@@ -112,12 +111,12 @@ FNakamaDeleteStorageObjectId::FNakamaDeleteStorageObjectId()
 	
 }
 
-FNakamaStoreObjectAck::FNakamaStoreObjectAck(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaStoreObjectAck::FNakamaStoreObjectAck(const FString& JsonString) : FNakamaStoreObjectAck(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaStoreObjectAck::FNakamaStoreObjectAck(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("collection"), Collection);
 		JsonObject->TryGetStringField(TEXT("key"), Key);
@@ -144,18 +143,9 @@ FNakamaStoreObjectAcks::FNakamaStoreObjectAcks(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& StorageJson : *StorageJobjectsJsonArray)
 			{
-				if (StorageJson->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> StorageJsonObject = StorageJson->AsObject())
 				{
-					TSharedPtr<FJsonObject> StorageJsonObject = StorageJson->AsObject();
-                
-					FString StorageObjectJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&StorageObjectJsonString);
-					if (FJsonSerializer::Serialize(StorageJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaStoreObjectAck StorageObject(StorageObjectJsonString);
-						StorageObjects.Add(StorageObject);
-					}
+					StorageObjects.Add(FNakamaStoreObjectAck(StorageJsonObject));
 				}
 			}
 		}
@@ -180,18 +170,9 @@ FNakamaStorageObjectList::FNakamaStorageObjectList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& StorageJson : *StorageJobjectsJsonArray)
 			{
-				if (StorageJson->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> StorageJsonObject = StorageJson->AsObject())
 				{
-					TSharedPtr<FJsonObject> StorageJsonObject = StorageJson->AsObject();
-                
-					FString StorageObjectJsonString;
-					auto Writer = TJsonWriterFactory<>::Create(&StorageObjectJsonString);
-					if (FJsonSerializer::Serialize(StorageJsonObject.ToSharedRef(), Writer))
-					{
-						Writer->Close();
-						FNakamaStoreObjectData StorageObject(StorageObjectJsonString);
-						Objects.Add(StorageObject);
-					}
+					Objects.Add(FNakamaStoreObjectData(StorageJsonObject));
 				}
 			}
 		}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaTournament.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaTournament.cpp
@@ -1,13 +1,12 @@
-﻿#include "NakamaTournament.h"
-
+#include "NakamaTournament.h"
 #include "NakamaUtils.h"
 
-FNakamaTournament::FNakamaTournament(const FString& JsonString)
-{
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+FNakamaTournament::FNakamaTournament(const FString& JsonString) : FNakamaTournament(FNakamaUtils::DeserializeJsonObject(JsonString)) {
+}
 
-	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+FNakamaTournament::FNakamaTournament(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
 		JsonObject->TryGetStringField(TEXT("id"), Id);
 		JsonObject->TryGetStringField(TEXT("title"), Title);
@@ -63,20 +62,9 @@ FNakamaTournamentRecordList::FNakamaTournamentRecordList(const FString& JsonStri
         {
             for (const TSharedPtr<FJsonValue>& RecordJson : *RecordsJsonArray)
             {
-                if (RecordJson->Type == EJson::Object)
+                if (TSharedPtr<FJsonObject> RecordJsonObject = RecordJson->AsObject())
                 {
-                    TSharedPtr<FJsonObject> RecordJsonObject = RecordJson->AsObject();
-                    if (RecordJsonObject.IsValid())
-                    {
-                        FString RecordJsonString;
-                        TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&RecordJsonString);
-                        if (FJsonSerializer::Serialize(RecordJsonObject.ToSharedRef(), JsonWriter))
-                        {
-                            JsonWriter->Close();
-                            FNakamaLeaderboardRecord Record(RecordJsonString);
-                            Records.Add(Record);
-                        }
-                    }
+                    Records.Add(FNakamaLeaderboardRecord(RecordJsonObject));
                 }
             }
         }
@@ -86,20 +74,9 @@ FNakamaTournamentRecordList::FNakamaTournamentRecordList(const FString& JsonStri
         {
             for (const TSharedPtr<FJsonValue>& OwnerRecordJson : *OwnerRecordsJsonArray)
             {
-                if (OwnerRecordJson->Type == EJson::Object)
+                if (TSharedPtr<FJsonObject> OwnerRecordJsonObject = OwnerRecordJson->AsObject())
                 {
-                    TSharedPtr<FJsonObject> OwnerRecordJsonObject = OwnerRecordJson->AsObject();
-                    if (OwnerRecordJsonObject.IsValid())
-                    {
-                        FString OwnerRecordJsonString;
-                        TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&OwnerRecordJsonString);
-                        if (FJsonSerializer::Serialize(OwnerRecordJsonObject.ToSharedRef(), JsonWriter))
-                        {
-                            JsonWriter->Close();
-                            FNakamaLeaderboardRecord OwnerRecord(OwnerRecordJsonString);
-                            OwnerRecords.Add(OwnerRecord);
-                        }
-                    }
+                    OwnerRecords.Add(FNakamaLeaderboardRecord(OwnerRecordJsonObject));
                 }
             }
         }
@@ -127,20 +104,9 @@ FNakamaTournamentList::FNakamaTournamentList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& TournamentJson : *TournamentsJsonArray)
 			{
-				if (TournamentJson->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> TournamentJsonObject = TournamentJson->AsObject())
 				{
-					TSharedPtr<FJsonObject> TournamentJsonObject = TournamentJson->AsObject();
-					if (TournamentJsonObject.IsValid())
-					{
-						FString TournamentJsonString;
-						TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&TournamentJsonString);
-						if (FJsonSerializer::Serialize(TournamentJsonObject.ToSharedRef(), JsonWriter))
-						{
-							JsonWriter->Close();
-							FNakamaTournament Tournament(TournamentJsonString);
-							Tournaments.Add(Tournament);
-						}
-					}
+					Tournaments.Add(FNakamaTournament(TournamentJsonObject));
 				}
 			}
 		}

--- a/Nakama/Source/NakamaUnreal/Public/NakamaAccountDevice.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaAccountDevice.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -21,5 +21,6 @@ struct NAKAMAUNREAL_API FNakamaAccountDevice
 	TMap<FString, FString> Vars;
 
 	FNakamaAccountDevice(const FString& JsonString);
+    FNakamaAccountDevice(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaAccountDevice();
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaChannelTypes.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaChannelTypes.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -80,6 +80,7 @@ struct NAKAMAUNREAL_API FNakamaChannelMessage
 	FString UserIdTwo;
 
 	FNakamaChannelMessage(const FString& JsonString);
+    FNakamaChannelMessage(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaChannelMessage(); // Default Constructor
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaClient.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaClient.h
@@ -33,6 +33,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnAuthRefreshError, const FNakamaEr
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUserAccountInfo, const FNakamaAccount&, AccountData);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetUsers, const TArray <FNakamaUser>&, Users);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnUpdateAccount);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnDeleteUser);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnFriendsList, FNakamaFriendList, Friends);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnReceivedFriendsList, FNakamaFriendList, list);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAddedFriend); //Add 's here
@@ -801,6 +802,20 @@ public:
 		const FString& Location,
 		const FString& Timezone,
 		FOnUpdateAccount Success,
+		FOnError Error
+	);
+
+	/**
+	 * Delete the current user from the server.
+	 *
+	 * @param Session The session of the user.
+	 * @param Success Delegate called upon successfully deleting the user's account.
+	 * @param Error Delegate called if the update operation fails, detailing the encountered error.
+	 */
+	UFUNCTION(Category = "Nakama|Users")
+	void DeleteUser(
+		UNakamaSession* Session,
+		FOnDeleteUser Success,
 		FOnError Error
 	);
 
@@ -2135,6 +2150,17 @@ public:
 		TFunction<void()> SuccessCallback,
 		TFunction<void(const FNakamaError& Error)> ErrorCallback
 	);
+
+
+	/**
+	 * Delete the current user from the server.
+	 *
+	 * @param Session The session of the user.
+	 * @param SuccessCallback Callback invoked upon successfully deleting the user's account.
+	 * @param ErrorCallback Callback invoked if the delete operation fails, detailing the encountered error.
+	 */
+	void DeleteUser(UNakamaSession* Session, TFunction<void()> SuccessCallback,
+	                TFunction<void(const FNakamaError& Error)> ErrorCallback);
 
 	// --- Users --- //
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaFriend.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaFriend.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -37,6 +37,7 @@ struct NAKAMAUNREAL_API FNakamaFriend
 	FDateTime UpdateTime;
 
 	FNakamaFriend(const FString& JsonString);
+    FNakamaFriend(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaFriend();
 
 	static ENakamaFriendState GetFriendStateFromString(const FString& StateString);

--- a/Nakama/Source/NakamaUnreal/Public/NakamaGroup.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaGroup.h
@@ -72,6 +72,7 @@ struct NAKAMAUNREAL_API FNakamaGroup
 	FDateTime UpdateTime = 0;
 
 	FNakamaGroup(const FString& JsonString);
+    FNakamaGroup(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaGroup() { }
 };
 
@@ -101,6 +102,7 @@ struct NAKAMAUNREAL_API FNakamaGroupUser
 	ENakamaGroupState State;
 
 	FNakamaGroupUser(const FString& JsonString);
+	FNakamaGroupUser(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaGroupUser();
 };
 
@@ -157,6 +159,7 @@ struct NAKAMAUNREAL_API FNakamaUserGroup
 	ENakamaGroupState State;
 
 	FNakamaUserGroup(const FString& JsonString);
+	FNakamaUserGroup(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaUserGroup();
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaLeaderboard.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaLeaderboard.h
@@ -58,7 +58,8 @@ struct NAKAMAUNREAL_API FNakamaLeaderboardRecord
 	int64 Rank = 0;
 
 	FNakamaLeaderboardRecord(const FString& JsonString);
-	FNakamaLeaderboardRecord();
+    FNakamaLeaderboardRecord(const TSharedPtr<FJsonObject> JsonObject);
+    FNakamaLeaderboardRecord();
 
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaMatch.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaMatch.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -36,6 +36,7 @@ struct NAKAMAUNREAL_API FNakamaMatch
 	FNakamaUserPresence Me;
 
 	FNakamaMatch(const FString& JsonString);
+    FNakamaMatch(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaMatch() : Authoritative(false), Size(0) { }
 
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaMatchTypes.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaMatchTypes.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -24,6 +24,7 @@ struct NAKAMAUNREAL_API FNakamaMatchmakerUser
 	TMap<FString, int32> NumericProperties;
 
 	FNakamaMatchmakerUser(const FString& JsonString);
+    FNakamaMatchmakerUser(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaMatchmakerUser();
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaNotification.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaNotification.h
@@ -38,6 +38,7 @@ struct NAKAMAUNREAL_API FNakamaNotification
 	bool Persistent = false;
 
 	FNakamaNotification(const FString& JsonString);
+    FNakamaNotification(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaNotification();
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaParty.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaParty.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "NakamaPresence.h"
@@ -36,6 +36,7 @@ struct NAKAMAUNREAL_API FNakamaParty
 	TArray<FNakamaUserPresence> Presences;
 
 	FNakamaParty(const FString& JsonString);
+    FNakamaParty(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaParty(); // Default Constructor
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaPresence.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaPresence.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -41,6 +41,7 @@ struct NAKAMAUNREAL_API FNakamaUserPresence
 	FString Status;
 
 	FNakamaUserPresence(const FString& JsonString);
+    FNakamaUserPresence(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaUserPresence();
 
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaStorageObject.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaStorageObject.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -49,6 +49,7 @@ struct NAKAMAUNREAL_API FNakamaStoreObjectData
 	FDateTime UpdateTime = 0;
 
 	FNakamaStoreObjectData(const FString& JsonString);
+	FNakamaStoreObjectData(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaStoreObjectData();
 };
 
@@ -159,6 +160,7 @@ struct NAKAMAUNREAL_API FNakamaStoreObjectAck
 	FString UserId;
 
 	FNakamaStoreObjectAck(const FString& JsonString);
+    FNakamaStoreObjectAck(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaStoreObjectAck();
 
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaStreams.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaStreams.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "NakamaPresence.h"
@@ -27,6 +27,7 @@ struct NAKAMAUNREAL_API FNakamaStream
 	FString Label;
 
 	FNakamaStream(const FString& JsonString);
+    FNakamaStream(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaStream();
 };
 

--- a/Nakama/Source/NakamaUnreal/Public/NakamaTournament.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaTournament.h
@@ -79,6 +79,7 @@ struct NAKAMAUNREAL_API FNakamaTournament
 	FString Metadata;
 
 	FNakamaTournament(const FString& JsonString);
+	FNakamaTournament(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaTournament();
 	
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaUser.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaUser.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
@@ -79,6 +79,7 @@ struct NAKAMAUNREAL_API FNakamaUser
 	FDateTime updatedAt;
 
 	FNakamaUser(const FString& JsonString);
+    FNakamaUser(const TSharedPtr<FJsonObject> JsonObject);
 	FNakamaUser(): EdgeCount(0), CreatedAt(0), updatedAt(0) { }
 
 };

--- a/Nakama/Source/NakamaUnreal/Public/NakamaUtils.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaUtils.h
@@ -102,6 +102,16 @@ public:
 		return true;
 	}
 
+	static TSharedPtr<FJsonObject> DeserializeJsonObject(const FString& JsonString) {
+		TSharedPtr<FJsonObject> JsonObject;
+		const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+		if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
+		{
+			JsonObject = nullptr;
+		}
+		return JsonObject;
+	}
+
 	static void AddVarsToJson(const TSharedPtr<FJsonObject>& JsonObject, const TMap<FString, FString>& Vars, const FString varsFieldName = TEXT("vars"), const bool addAlways = false) {
 
 		if (addAlways || Vars.Num() > 0)

--- a/Satori/Source/SatoriBlueprints/Private/SatoriClientRequests.cpp
+++ b/Satori/Source/SatoriBlueprints/Private/SatoriClientRequests.cpp
@@ -641,6 +641,70 @@ void USatoriClientGetFlags::Activate()
 	SatoriClient->GetFlags(UserSession, Names, successCallback, errorCallback);
 }
 
+USatoriClientGetFlagOverrides* USatoriClientGetFlagOverrides::GetFlagOverrides(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& Names)
+{
+	USatoriClientGetFlagOverrides* Node = NewObject<USatoriClientGetFlagOverrides>();
+	Node->SatoriClient = Client;
+	Node->UserSession = Session;
+	Node->Names = Names;
+
+	return Node;
+}
+
+void USatoriClientGetFlagOverrides::Activate()
+{
+	// Check validity of client and session
+	if (!SatoriClient && !UserSession)
+	{
+		const FNakamaError Error = FNakamaUtils::HandleInvalidClientAndSession();
+		OnError.Broadcast({}, Error);
+		SetReadyToDestroy();
+		return;
+	}
+
+	if (!SatoriClient)
+	{
+		const FNakamaError Error = FNakamaUtils::HandleInvalidClient();
+		OnError.Broadcast({}, Error);
+		SetReadyToDestroy();
+		return;
+	}
+
+	if (!UserSession)
+	{
+		const FNakamaError Error = FNakamaUtils::HandleInvalidSession();
+		OnError.Broadcast({}, Error);
+		SetReadyToDestroy();
+		return;
+	}
+
+	auto successCallback = [this](const FSatoriFlagOverrideList& FlagOverrides)
+		{
+			if (!USatoriClient::IsClientActive(SatoriClient))
+			{
+				SetReadyToDestroy();
+				return;
+			}
+
+			OnSuccess.Broadcast(FlagOverrides, {});
+			SetReadyToDestroy();
+		};
+
+	auto errorCallback = [this](const FNakamaError& error)
+		{
+			if (!USatoriClient::IsClientActive(SatoriClient))
+			{
+				SetReadyToDestroy();
+				return;
+			}
+
+			OnError.Broadcast({}, error);
+			SetReadyToDestroy();
+		};
+
+	SatoriClient->GetFlagOverrides(UserSession, Names, successCallback, errorCallback);
+}
+
 USatoriClientGetLiveEvents* USatoriClientGetLiveEvents::GetLiveEvents(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& LiveEventNames)
 {
 	USatoriClientGetLiveEvents* Node = NewObject<USatoriClientGetLiveEvents>();

--- a/Satori/Source/SatoriBlueprints/Public/SatoriClientRequests.h
+++ b/Satori/Source/SatoriBlueprints/Public/SatoriClientRequests.h
@@ -21,6 +21,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSatoriDeleteIdentity, FNakamaErro
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSatoriPostEvent, FNakamaError, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSatoriGetExperiments, FSatoriExperimentList, Experiments, FNakamaError, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSatoriGetFlags, FSatoriFlagList, Flags, FNakamaError, Error);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSatoriGetFlagOverrides, FSatoriFlagOverrideList, FlagOverrides, FNakamaError, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSatoriGetLiveEvents, FSatoriLiveEventList, LiveEvents, FNakamaError, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSatoriGetMessages, FSatoriMessageList, Messages, FNakamaError, Error);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSatoriUpdateMessage, FNakamaError, Error);
@@ -59,7 +60,7 @@ public:
 	 * @param CreateAccount True if the user should be created when authenticated.
 	 * @param Vars Extra information that will be bundled in the session token.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|Authentication", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|Authentication", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "Vars"))
 	static USatoriClientAuthenticateCustom* AuthenticateCustom(
 		USatoriClient *Client,
 		const FString& UserID,
@@ -181,7 +182,7 @@ public:
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|Identity", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|Identity", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "DefaultProperties,CustomProperties"))
 	static USatoriClientIdentify* Identify(
 		USatoriClient* Client,
 		UNakamaSession* Session,
@@ -224,7 +225,6 @@ public:
 	/**
 	 * Post one or more events.
 	 *
-	 * @param Events The ids of the users to add or invite as friends.
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
@@ -265,7 +265,7 @@ public:
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|Identity", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|Identity", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "DefaultProperties,CustomProperties"))
 	static USatoriClientUpdateProperties* UpdateProperties(
 		USatoriClient* Client, 
 		UNakamaSession* Session,
@@ -308,7 +308,6 @@ public:
 	/**
 	 * Post one or more events.
 	 *
-	 * @param Events The ids of the users to add or invite as friends.
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
@@ -349,7 +348,7 @@ public:
 	/**
 	 * Post one or more events.
 	 *
-	 * @param Events The ids of the users to add or invite as friends.
+	 * @param Events The events to publish.
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
@@ -389,11 +388,11 @@ public:
 	/**
 	 * Post one or more events.
 	 *
-	 * @param Events The ids of the users to add or invite as friends.
+	 * @param Names The ids of the experiments to query. Leave empty or pass an empty array to get them all.
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|Experiments", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|Experiments", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "Names"))
 	static USatoriClientGetExperiments* GetExperiments(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& Names);
 
 	virtual void Activate() override;
@@ -429,12 +428,52 @@ public:
 	/**
 	 * Post one or more events.
 	 *
-	 * @param Events The ids of the users to add or invite as friends.
+	 * @param Names The ids of the flags to query. Leave empty or pass an empty array to get them all.
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|Flags", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|Flags", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "Names"))
 	static USatoriClientGetFlags* GetFlags(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& Names);
+
+	virtual void Activate() override;
+
+private:
+	TArray<FString> Names;
+};
+
+
+/**
+ * Get flags
+ */
+
+UCLASS()
+class SATORIBLUEPRINTS_API USatoriClientGetFlagOverrides : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+public:
+
+	UPROPERTY()
+	TObjectPtr<USatoriClient> SatoriClient;
+
+	UPROPERTY()
+	TObjectPtr<UNakamaSession> UserSession;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnSatoriGetFlagOverrides OnSuccess;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnSatoriGetFlagOverrides OnError;
+
+	/**
+	 * Post one or more events.
+	 *
+	 * @param Names The ids of the flags to query overrides for. Leave empty or pass an empty array to get them all.
+	 * @param Session The session of the user.
+	 * @param Client The Client to use.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Satori|Flags", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "Names"))
+	static USatoriClientGetFlagOverrides* GetFlagOverrides(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& Names);
 
 	virtual void Activate() override;
 
@@ -473,7 +512,7 @@ public:
 	 * @param Session The session of the user.
 	 * @param Client The Client to use.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Satori|LiveEvents", meta = (BlueprintInternalUseOnly = "true"))
+	UFUNCTION(BlueprintCallable, Category = "Satori|LiveEvents", meta = (BlueprintInternalUseOnly = "true", AutoCreateRefTerm = "LiveEventNames"))
 	static USatoriClientGetLiveEvents* GetLiveEvents(USatoriClient* Client, UNakamaSession* Session, const TArray<FString>& LiveEventNames);
 
 	virtual void Activate() override;

--- a/Satori/Source/SatoriUnreal/Private/SatoriEvent.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriEvent.cpp
@@ -2,15 +2,7 @@
 
 #include "NakamaUtils.h"
 
-FSatoriEvent::FSatoriEvent(const FString& JsonString) : FSatoriEvent([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-	{
-		JsonObject = nullptr;
-	}
-	return JsonObject;
-	}(JsonString)) {
+FSatoriEvent::FSatoriEvent(const FString& JsonString) : FSatoriEvent(FNakamaUtils::DeserializeJsonObject(JsonString)) {
 }
 
 FSatoriEvent::FSatoriEvent(const TSharedPtr<FJsonObject> JsonObject)

--- a/Satori/Source/SatoriUnreal/Private/SatoriExperiment.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriExperiment.cpp
@@ -1,15 +1,7 @@
 #include "SatoriExperiment.h"
-#include "SatoriExperiment.h"
+#include "NakamaUtils.h"
 
-FSatoriExperiment::FSatoriExperiment(const FString& JsonString) : FSatoriExperiment([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-	{
-		JsonObject = nullptr;
-	}
-	return JsonObject;
-	}(JsonString)) {
+FSatoriExperiment::FSatoriExperiment(const FString& JsonString) : FSatoriExperiment(FNakamaUtils::DeserializeJsonObject(JsonString)) {
 }
 
 FSatoriExperiment::FSatoriExperiment(const TSharedPtr<FJsonObject> JsonObject)
@@ -36,9 +28,8 @@ FSatoriExperimentList::FSatoriExperimentList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& ExperimentJsonValue : *ExperimentsJsonArray)
 			{
-				if (ExperimentJsonValue->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> ExperimentJsonObject = ExperimentJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> ExperimentJsonObject = ExperimentJsonValue->AsObject();
 					FSatoriExperiment Experiment(ExperimentJsonObject);
 					if (!Experiment.Name.IsEmpty())
 					{

--- a/Satori/Source/SatoriUnreal/Private/SatoriFlag.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriFlag.cpp
@@ -1,15 +1,33 @@
 #include "SatoriFlag.h"
+#include "NakamaUtils.h"
 
-FSatoriFlag::FSatoriFlag(const FString& JsonString) : FSatoriFlag([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
+FSatoriFlagValueChangeReason::FSatoriFlagValueChangeReason(const FString& JsonString) : FSatoriFlagValueChangeReason(FNakamaUtils::DeserializeJsonObject(JsonString))
+{
+}
+
+FSatoriFlagValueChangeReason::FSatoriFlagValueChangeReason(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
 	{
-		JsonObject = nullptr;
+		JsonObject->TryGetStringField(TEXT("name"), Name);
+		JsonObject->TryGetStringField(TEXT("variant_name"), VariantName);
+		double typeNum;
+		if (JsonObject->TryGetNumberField(TEXT("type"), typeNum)) {
+			int typeInt = (int)typeNum;
+			if (typeInt >= static_cast<int>(FSatoriFlagValueChangeReasonType::UNKNOWN) && typeInt <= static_cast<int>(FSatoriFlagValueChangeReasonType::EXPERIMENT)) {
+				Type = static_cast<FSatoriFlagValueChangeReasonType>(typeInt);
+			}
+		}
 	}
-	return JsonObject;
-	}(JsonString)){}
+}
 
+FSatoriFlagValueChangeReason::FSatoriFlagValueChangeReason()
+{
+}
+
+FSatoriFlag::FSatoriFlag(const FString& JsonString) : FSatoriFlag(FNakamaUtils::DeserializeJsonObject(JsonString))
+{
+}
 
 FSatoriFlag::FSatoriFlag(const TSharedPtr<FJsonObject> JsonObject)
 {
@@ -17,8 +35,11 @@ FSatoriFlag::FSatoriFlag(const TSharedPtr<FJsonObject> JsonObject)
 	{
 		JsonObject->TryGetStringField(TEXT("name"), Name);
 		JsonObject->TryGetStringField(TEXT("value"), Value);
-		// TODO: Figure out how to obtain this value and set it here if it can be obtained from the json we have
-		bConditionChanged = false;	//JsonObject->TryGetBoolField(TEXT("???"), bConditionChanged);
+		JsonObject->TryGetBoolField(TEXT("condition_changed"), bConditionChanged);
+		const TSharedPtr<FJsonObject>* ChangeReasonObject = nullptr;
+		if (JsonObject->TryGetObjectField(TEXT("change_reason"), ChangeReasonObject)) {
+			ChangeReason = FSatoriFlagValueChangeReason(*ChangeReasonObject);
+		}
 	}
 }
 
@@ -37,9 +58,8 @@ FSatoriFlagList::FSatoriFlagList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& FlagJsonValue : *FlagsJsonArray)
 			{
-				if (FlagJsonValue->Type == EJson::Object)
+				if (TSharedPtr<FJsonObject> FlagJsonObject = FlagJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> FlagJsonObject = FlagJsonValue->AsObject();
 					FSatoriFlag Flag(FlagJsonObject);
 					if (!Flag.Name.IsEmpty())
 					{
@@ -52,5 +72,90 @@ FSatoriFlagList::FSatoriFlagList(const FString& JsonString)
 }
 
 FSatoriFlagList::FSatoriFlagList()
+{
+}
+
+FSatoriFlagOverrideValue::FSatoriFlagOverrideValue(const FString& JsonString) : FSatoriFlagOverrideValue(FNakamaUtils::DeserializeJsonObject(JsonString))
+{
+}
+
+FSatoriFlagOverrideValue::FSatoriFlagOverrideValue(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
+	{
+		JsonObject->TryGetStringField(TEXT("name"), Name);
+		JsonObject->TryGetStringField(TEXT("variant_name"), VariantName);
+		JsonObject->TryGetStringField(TEXT("value"), Value);
+		double typeNum;
+		if (JsonObject->TryGetNumberField(TEXT("type"), typeNum)) {
+			int typeInt = (int)typeNum;
+			if (typeInt >= static_cast<int>(FSatoriFlagOverrideType::FLAG) && typeInt <= static_cast<int>(FSatoriFlagOverrideType::EXPERIMENT_PHASE_VARIANT_FLAG)) {
+				Type = static_cast<FSatoriFlagOverrideType>(typeInt);
+			}
+		}
+	}
+}
+
+FSatoriFlagOverrideValue::FSatoriFlagOverrideValue()
+{
+}
+
+FSatoriFlagOverride::FSatoriFlagOverride(const FString& JsonString) : FSatoriFlagOverride(FNakamaUtils::DeserializeJsonObject(JsonString))
+{
+}
+
+FSatoriFlagOverride::FSatoriFlagOverride(const TSharedPtr<FJsonObject> JsonObject)
+{
+	if (JsonObject.IsValid())
+	{
+		JsonObject->TryGetStringField(TEXT("flag_name"), FlagName);
+		const TArray<TSharedPtr<FJsonValue>>* OverridesJsonArray;
+		if (JsonObject->TryGetArrayField(TEXT("overrides"), OverridesJsonArray))
+		{
+			for (const TSharedPtr<FJsonValue>& OverrideJsonValue : *OverridesJsonArray)
+			{
+				if (TSharedPtr<FJsonObject> OverrideJsonObject = OverrideJsonValue->AsObject())
+				{
+					FSatoriFlagOverrideValue Override(OverrideJsonObject);
+					Overrides.Add(Override);
+				}
+			}
+		}
+	}
+	// Flag name
+	std::string flag_name;
+	// The list of configuration that affect the value of the flag.
+	std::vector<FSatoriFlagOverrideValue> overrides;
+}
+
+FSatoriFlagOverride::FSatoriFlagOverride()
+{
+}
+
+FSatoriFlagOverrideList::FSatoriFlagOverrideList(const FString& JsonString)
+{
+	TSharedPtr<FJsonObject> JsonObject;
+	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
+	if (FJsonSerializer::Deserialize(JsonReader, JsonObject) && JsonObject.IsValid())
+	{
+		const TArray<TSharedPtr<FJsonValue>>* FlagOverridesJsonArray;
+		if (JsonObject->TryGetArrayField(TEXT("flags"), FlagOverridesJsonArray))
+		{
+			for (const TSharedPtr<FJsonValue>& FlagOverrideJsonValue : *FlagOverridesJsonArray)
+			{
+				if (TSharedPtr<FJsonObject> FlagOverrideJsonObject = FlagOverrideJsonValue->AsObject())
+				{
+					FSatoriFlagOverride FlagOverride(FlagOverrideJsonObject);
+					if (!FlagOverride.FlagName.IsEmpty())
+					{
+						Flags.Add(FlagOverride);
+					}
+				}
+			}
+		}
+	}
+}
+
+FSatoriFlagOverrideList::FSatoriFlagOverrideList()
 {
 }

--- a/Satori/Source/SatoriUnreal/Private/SatoriLiveEvent.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriLiveEvent.cpp
@@ -1,14 +1,7 @@
 #include "SatoriLiveEvent.h"
+#include "NakamaUtils.h"
 
-FSatoriLiveEvent::FSatoriLiveEvent(const FString& JsonString) : FSatoriLiveEvent([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-	{
-		JsonObject = nullptr;
-	}
-	return JsonObject;
-	}(JsonString)) {
+FSatoriLiveEvent::FSatoriLiveEvent(const FString& JsonString) : FSatoriLiveEvent(FNakamaUtils::DeserializeJsonObject(JsonString)) {
 }
 
 FSatoriLiveEvent::FSatoriLiveEvent(const TSharedPtr<FJsonObject> JsonObject)
@@ -43,9 +36,8 @@ FSatoriLiveEventList::FSatoriLiveEventList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& LiveEventJsonValue : *LiveEventsJsonArray)
 			{
-				if (LiveEventJsonValue->Type == EJson::Object)
+				if(TSharedPtr<FJsonObject> LiveEventJsonObject = LiveEventJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> LiveEventJsonObject = LiveEventJsonValue->AsObject();
 					FSatoriLiveEvent LiveEvent(LiveEventJsonObject);
 					if (!LiveEvent.Name.IsEmpty())
 					{

--- a/Satori/Source/SatoriUnreal/Private/SatoriMessage.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriMessage.cpp
@@ -1,14 +1,7 @@
 #include "SatoriMessage.h"
+#include "NakamaUtils.h"
 
-FSatoriMessage::FSatoriMessage(const FString& JsonString) : FSatoriMessage([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-	{
-		JsonObject = nullptr;
-	}
-	return JsonObject;
-	}(JsonString)) {
+FSatoriMessage::FSatoriMessage(const FString& JsonString) : FSatoriMessage(FNakamaUtils::DeserializeJsonObject(JsonString)) {
 }
 
 FSatoriMessage::FSatoriMessage(const TSharedPtr<FJsonObject> JsonObject)
@@ -50,9 +43,8 @@ FSatoriMessageList::FSatoriMessageList(const FString& JsonString)
 		{
 			for (const TSharedPtr<FJsonValue>& MessageJsonValue : *MessagesJsonArray)
 			{
-				if (MessageJsonValue->Type == EJson::Object)
+				if(TSharedPtr<FJsonObject> MessageJsonObject = MessageJsonValue->AsObject())
 				{
-					TSharedPtr<FJsonObject> MessageJsonObject = MessageJsonValue->AsObject();
 					FSatoriMessage Message(MessageJsonObject);
 					if (!Message.ID.IsEmpty())
 					{

--- a/Satori/Source/SatoriUnreal/Private/SatoriProperties.cpp
+++ b/Satori/Source/SatoriUnreal/Private/SatoriProperties.cpp
@@ -1,14 +1,7 @@
 #include "SatoriProperties.h"
+#include "NakamaUtils.h"
 
-FSatoriProperties::FSatoriProperties(const FString& JsonString) : FSatoriProperties([](const FString& JsonString) {
-	TSharedPtr<FJsonObject> JsonObject;
-	const TSharedRef<TJsonReader<>> JsonReader = TJsonReaderFactory<>::Create(JsonString);
-	if (!FJsonSerializer::Deserialize(JsonReader, JsonObject))
-	{
-		JsonObject = nullptr;
-	}
-	return JsonObject;
-	}(JsonString)) {
+FSatoriProperties::FSatoriProperties(const FString& JsonString) : FSatoriProperties(FNakamaUtils::DeserializeJsonObject(JsonString)) {
 }
 
 FSatoriProperties::FSatoriProperties(const TSharedPtr<FJsonObject> JsonObject)

--- a/Satori/Source/SatoriUnreal/Public/SatoriClient.h
+++ b/Satori/Source/SatoriUnreal/Public/SatoriClient.h
@@ -26,6 +26,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSatoriError, const FNakamaError&,
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPostEventSent);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetExperiments, const FSatoriExperimentList&, Experiments);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetFlags, const FSatoriFlagList&, Flags);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetFlagOverrides, const FSatoriFlagOverrideList&, FlagOverrides);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetLiveEvents, const FSatoriLiveEventList&, LiveEvents);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGetProperties, const FSatoriProperties&, Properties);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnUpdatePropertiesSent);
@@ -71,6 +72,34 @@ public:
 	// Initialize System, this has to be called first, done via the Library Action instead (removed BlueprintCallable)
 	UFUNCTION(Category = "Satori|Initialize")
 	void InitializeSystem(const FString& InServerKey, const FString& Host, int32 InPort, bool UseSSL, bool EnableDebug);
+
+	/**
+	 * Disconnects the client. This function kills all outgoing exchanges immediately without waiting.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Satori|Client", meta = (DeprecatedFunction, DeprecationMessage = "Use CancelAllRequests instead"))
+	void Disconnect();
+
+	/**
+	 * Cancels all Requests. This function kills all outgoing exchanges immediately without waiting.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Satori|Client")
+	void CancelAllRequests();
+
+	/**
+	 * Destroys the Client.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Satori|Client")
+	void Destroy();
+
+	// Manage Timeout
+	UFUNCTION(BlueprintCallable, Category = "Satori|Client")
+	void SetTimeout(float InTimeout);
+
+	UFUNCTION(BlueprintCallable, Category = "Satori|Client")
+	float GetTimeout();
+
+	// Event that is called on cleanup
+	virtual void BeginDestroy() override;
 
 	/**
 	 * Creates a default client to interact with Satori server.
@@ -256,6 +285,21 @@ public:
 		UNakamaSession* Session,
 		const TArray<FString>& Names,
 		TFunction<void(const FSatoriFlagList& Flags)> SuccessCallback,
+		TFunction<void(const FNakamaError& Error)> ErrorCallback
+	);
+
+	UFUNCTION(Category = "Satori|Flags")
+	void GetFlagOverrides(
+		UNakamaSession* Session,
+		const TArray<FString>& Names,
+		FOnGetFlagOverrides Success,
+		FOnSatoriError Error
+	);
+
+	void GetFlagOverrides(
+		UNakamaSession* Session,
+		const TArray<FString>& Names,
+		TFunction<void(const FSatoriFlagOverrideList& Flags)> SuccessCallback,
 		TFunction<void(const FNakamaError& Error)> ErrorCallback
 	);
 

--- a/Satori/Source/SatoriUnreal/Public/SatoriFlag.h
+++ b/Satori/Source/SatoriUnreal/Public/SatoriFlag.h
@@ -5,6 +5,37 @@
 
 
 // Flags
+UENUM(BlueprintType)
+enum class FSatoriFlagValueChangeReasonType : uint8
+{
+	UNKNOWN = 0,
+	FLAG_VARIANT = 1,
+	LIVE_EVENT = 2,
+	EXPERIMENT = 3
+};
+
+USTRUCT(BlueprintType)
+struct SATORIUNREAL_API FSatoriFlagValueChangeReason
+{
+	GENERATED_BODY()
+
+	// The type of the configuration that declared the override.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FSatoriFlagValueChangeReasonType Type = FSatoriFlagValueChangeReasonType::UNKNOWN;
+
+	// The name of the configuration that overrides the flag value.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString Name;
+
+	// The variant name of the configuration that overrides the flag value.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString VariantName;
+
+	FSatoriFlagValueChangeReason(const FString& JsonString);
+	FSatoriFlagValueChangeReason(const TSharedPtr<FJsonObject> JsonObject);
+	FSatoriFlagValueChangeReason(); // Default Constructor
+};
+
 USTRUCT(BlueprintType)
 struct SATORIUNREAL_API FSatoriFlag
 {
@@ -20,7 +51,11 @@ struct SATORIUNREAL_API FSatoriFlag
 
 	// Whether the value for this flag has conditionally changed from the default state.
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
-	bool bConditionChanged;
+	bool bConditionChanged = false;
+
+	// The origin of change on the flag value returned.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FSatoriFlagValueChangeReason ChangeReason;
 
 	FSatoriFlag(const FString& JsonString);
 	FSatoriFlag(const TSharedPtr<FJsonObject> JsonObject);
@@ -38,4 +73,78 @@ struct SATORIUNREAL_API FSatoriFlagList
 
 	FSatoriFlagList(const FString& JsonString);
 	FSatoriFlagList(); // Default Constructor
+};
+
+
+// Flag Overrides
+
+UENUM(BlueprintType)
+enum class FSatoriFlagOverrideType : uint8
+{
+	FLAG = 0,
+	FLAG_VARIANT = 1,
+	LIVE_EVENT_FLAG = 2,
+	LIVE_EVENT_FLAG_VARIANT = 3,
+	EXPERIMENT_PHASE_VARIANT_FLAG = 4
+};
+
+USTRUCT(BlueprintType)
+struct SATORIUNREAL_API FSatoriFlagOverrideValue
+{
+	GENERATED_BODY()
+
+	// The type of the configuration that declared the override.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FSatoriFlagOverrideType Type = FSatoriFlagOverrideType::FLAG;
+
+	// The name of the configuration that overrides the flag value.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString Name;
+
+	// The variant name of the configuration that overrides the flag value.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString VariantName;
+
+	// The value of the configuration that overrides the flag.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString Value;
+
+	// The create time of the configuration that overrides the flag.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	int64 CreateTimeSec;
+
+	FSatoriFlagOverrideValue(const FString& JsonString);
+	FSatoriFlagOverrideValue(const TSharedPtr<FJsonObject> JsonObject);
+	FSatoriFlagOverrideValue(); // Default Constructor
+};
+
+USTRUCT(BlueprintType)
+struct SATORIUNREAL_API FSatoriFlagOverride
+{
+	GENERATED_BODY()
+
+	// Flag name
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	FString FlagName;
+
+	// The list of configuration that affect the value of the flag.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	TArray<FSatoriFlagOverrideValue> Overrides;
+
+	FSatoriFlagOverride(const FString& JsonString);
+	FSatoriFlagOverride(const TSharedPtr<FJsonObject> JsonObject);
+	FSatoriFlagOverride(); // Default Constructor
+};
+
+USTRUCT(BlueprintType)
+struct SATORIUNREAL_API FSatoriFlagOverrideList
+{
+	GENERATED_BODY()
+
+	// Flags.
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Satori|Flags")
+	TArray<FSatoriFlagOverride> Flags;
+
+	FSatoriFlagOverrideList(const FString& JsonString);
+	FSatoriFlagOverrideList(); // Default Constructor
 };


### PR DESCRIPTION
Add Satori Get Flag Overrides function and load additional Get Flag info.
Remove unnecessary serialization.
Add proper destructors to satori client.
Satori client blueprint calls now have default constructors for arrays and maps, so those pins now can be left disconnected if no data is to be sent there.