### PR TITLE
fix: nakama-unreal: session: RestoreSession now return UnakamaSession::SetupSession value

### DIFF
--- a/Nakama/Source/NakamaUnreal/Private/NakamaSession.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaSession.cpp
@@ -196,9 +196,7 @@ UNakamaSession* UNakamaSession::RestoreSession(FString Token, FString RefreshTok
 	// Check if serialization was successful
 	if (bSerializationSuccessful)
 	{
-		UNakamaSession* ResultSession = NewObject<UNakamaSession>();
-		ResultSession->SetupSession(JsonString);
-		return ResultSession;
+		return UNakamaSession::SetupSession(JsonString);
 	}
 	else
 	{


### PR DESCRIPTION
UNakamaSession::RestoreSession method is broken by incorrect using of UNakamaSession::SetupSession, fix this issue.