### PR TITLE
[SDK-940] Force include cacert.pem in final builds.

### DIFF
--- a/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
+++ b/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
@@ -74,5 +74,13 @@ public class NakamaUnreal : ModuleRules
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 
         PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+        
+        RuntimeDependencies.Add(Path.Combine(
+	        EngineDirectory,
+	        "Content",
+	        "Certificates",
+	        "ThirdParty",
+	        "cacert.pem"
+        ), StagedFileType.NonUFS);
     }
 }

--- a/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
+++ b/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
@@ -74,5 +74,13 @@ public class SatoriUnreal : ModuleRules
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 
         PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
+        
+        RuntimeDependencies.Add(Path.Combine(
+	        EngineDirectory,
+	        "Content",
+	        "Certificates",
+	        "ThirdParty",
+	        "cacert.pem"
+        ), StagedFileType.NonUFS);
     }
 }


### PR DESCRIPTION
Forces copies of `cacert.pem` being made upon Nakama/Satori builds.