### PR TITLE
Initialize Online variable to false

### DIFF
--- a/Nakama/Source/NakamaUnreal/Public/NakamaUser.h
+++ b/Nakama/Source/NakamaUnreal/Public/NakamaUser.h
@@ -90,7 +90,7 @@ struct NAKAMAUNREAL_API FNakamaUser
 	
 	// Indicates whether the user is currently online.
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Nakama|User")
-	bool Online;
+	bool Online = false;
 
 	FNakamaUser(const FString& JsonString);
     FNakamaUser(const TSharedPtr<class FJsonObject> JsonObject);


### PR DESCRIPTION
this is required if when fetching the friend list, the Online boolean is omitted so the Online boolean in the Struct will be false the default state, other wise it will be initialised with garbage value(that can be true also) which lead to wrong read of this field, please review and add this.