### PR TITLE
Introduce a temporary engine version-based define for legacy JSON Keys

### DIFF
--- a/IntegrationTests/Source/IntegrationTests.Target.cs
+++ b/IntegrationTests/Source/IntegrationTests.Target.cs
@@ -10,5 +10,12 @@ public class IntegrationTestsTarget : TargetRules
 		Type = TargetType.Game;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 		bUseLoggingInShipping = true;
+		
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			bOverrideBuildEnvironment = true;
+			CppStandard = CppStandardVersion.Cpp20;
+			GlobalDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 	}
 }

--- a/IntegrationTests/Source/IntegrationTests.Target.cs
+++ b/IntegrationTests/Source/IntegrationTests.Target.cs
@@ -11,11 +11,10 @@ public class IntegrationTestsTarget : TargetRules
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 		bUseLoggingInShipping = true;
 		
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
-			bOverrideBuildEnvironment = true;
-			CppStandard = CppStandardVersion.Cpp20;
-			GlobalDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+#if UE_5_8_OR_LATER
+		bOverrideBuildEnvironment = true;
+		CppStandard = CppStandardVersion.Cpp20;
+		GlobalDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 	}
 }

--- a/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
+++ b/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
@@ -11,11 +11,10 @@ public class IntegrationTestsEditorTarget : TargetRules
 		DefaultBuildSettings = BuildSettingsVersion.V6;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
+		#if UE_5_8_OR_LATER
 			bOverrideBuildEnvironment = true;
 			CppStandard = CppStandardVersion.Cpp20;
 			GlobalDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+		#endif
 	}
 }

--- a/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
+++ b/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
@@ -11,5 +11,11 @@ public class IntegrationTestsEditorTarget : TargetRules
 		DefaultBuildSettings = BuildSettingsVersion.V6;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			bOverrideBuildEnvironment = true;
+			CppStandard = CppStandardVersion.Cpp20;
+			GlobalDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 	}
 }

--- a/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
+++ b/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
@@ -21,6 +21,11 @@ public class NakamaBlueprints : ModuleRules
 	public NakamaBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			CppStandard = CppStandardVersion.Cpp20;
+			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
+++ b/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
@@ -21,11 +21,10 @@ public class NakamaBlueprints : ModuleRules
 	public NakamaBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
-			CppStandard = CppStandardVersion.Cpp20;
-			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+#if UE_5_8_OR_LATER
+		CppStandard = CppStandardVersion.Cpp20;
+		PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaTests/NakamaTests.Build.cs
+++ b/Nakama/Source/NakamaTests/NakamaTests.Build.cs
@@ -20,6 +20,10 @@ public class NakamaTests : ModuleRules
 {
 	public NakamaTests(ReadOnlyTargetRules Target) : base(Target)
 	{
+#if UE_5_8_OR_LATER
+		CppStandard = CppStandardVersion.Cpp20;
+		PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicIncludePaths.AddRange(

--- a/Nakama/Source/NakamaTests/Private/Tests/Test_Errors.cpp
+++ b/Nakama/Source/NakamaTests/Private/Tests/Test_Errors.cpp
@@ -78,7 +78,7 @@ inline bool ErrorInvalidArgument::RunTest(const FString& Parameters)
 	// Define error callback
 	auto errorCallback = [&](const FNakamaError& Error)
 	{
-		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), Error.Code );
+		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), static_cast<int>(Error.Code) );
 		TestTrue("Invalid Argument Test Passed", Error.Code == ENakamaErrorCode::InvalidArgument); 
 		StopTest();
 	};
@@ -115,7 +115,7 @@ inline bool ErrorInvalidArgument2::RunTest(const FString& Parameters)
 	// Define error callback
 	auto errorCallback = [&](const FNakamaError& Error)
 	{
-		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), Error.Code );
+		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), static_cast<int>(Error.Code) );
 		TestTrue("Invalid Argument 2 Test Passed", Error.Code == ENakamaErrorCode::InvalidArgument); 
 		StopTest();
 	};

--- a/Nakama/Source/NakamaTests/Private/Tests/Test_Storage.cpp
+++ b/Nakama/Source/NakamaTests/Private/Tests/Test_Storage.cpp
@@ -35,7 +35,7 @@ inline bool WriteStorageInvalidArgument::RunTest(const FString& Parameters)
 		auto errorCallback = [this](const FNakamaError& Error)
 		{
 			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorMessage: %s"), *Error.Message);
-			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorCode: %d"), Error.Code);
+			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorCode: %d"), static_cast<int>(Error.Code));
 			TestTrue("Write Storage Invalid Argument Passed.", Error.Code == ENakamaErrorCode::InvalidArgument);
 			StopTest();
 		};

--- a/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
+++ b/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
@@ -21,6 +21,11 @@ public class NakamaUnreal : ModuleRules
 {
 	public NakamaUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			CppStandard = CppStandardVersion.Cpp20;
+			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicIncludePaths.AddRange(

--- a/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
+++ b/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
@@ -21,11 +21,10 @@ public class NakamaUnreal : ModuleRules
 {
 	public NakamaUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
-			CppStandard = CppStandardVersion.Cpp20;
-			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+#if UE_5_8_OR_LATER
+		CppStandard = CppStandardVersion.Cpp20;
+		PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicIncludePaths.AddRange(

--- a/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
+++ b/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
@@ -21,6 +21,11 @@ public class SatoriBlueprints : ModuleRules
 	public SatoriBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			CppStandard = CppStandardVersion.Cpp20;
+			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
+++ b/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
@@ -21,11 +21,10 @@ public class SatoriBlueprints : ModuleRules
 	public SatoriBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
-			CppStandard = CppStandardVersion.Cpp20;
-			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+#if UE_5_8_OR_LATER
+		CppStandard = CppStandardVersion.Cpp20;
+		PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
+++ b/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
@@ -21,6 +21,11 @@ public class SatoriUnreal : ModuleRules
 {
 	public SatoriUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
+		{
+			CppStandard = CppStandardVersion.Cpp20;
+			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+		}
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicIncludePaths.AddRange(

--- a/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
+++ b/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
@@ -21,11 +21,10 @@ public class SatoriUnreal : ModuleRules
 {
 	public SatoriUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
-		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 8)
-		{
-			CppStandard = CppStandardVersion.Cpp20;
-			PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
-		}
+#if UE_5_8_OR_LATER
+		CppStandard = CppStandardVersion.Cpp20;
+		PublicDefinitions.Add("UE_JSONOBJECT_LEGACY_STRING_KEYS=1");
+#endif
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicIncludePaths.AddRange(


### PR DESCRIPTION
Unreal 5.8 is moving away from FString keys for JSON Objects.
FSharedString would be used instead.
As a temporary measure, we introduce a flag to override this behavior.