### PR TITLE
Fix compatibility issues with Unreal Engine 5.8

### DIFF
--- a/IntegrationTests/Source/IntegrationTests.Target.cs
+++ b/IntegrationTests/Source/IntegrationTests.Target.cs
@@ -8,7 +8,6 @@ public class IntegrationTestsTarget : TargetRules
 	public IntegrationTestsTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
-		CppStandard = CppStandardVersion.Cpp20;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 		bUseLoggingInShipping = true;
 	}

--- a/IntegrationTests/Source/IntegrationTests.Target.cs
+++ b/IntegrationTests/Source/IntegrationTests.Target.cs
@@ -8,6 +8,7 @@ public class IntegrationTestsTarget : TargetRules
 	public IntegrationTestsTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Game;
+		CppStandard = CppStandardVersion.Cpp20;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 		bUseLoggingInShipping = true;
 	}

--- a/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
+++ b/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
@@ -8,8 +8,11 @@ public class IntegrationTestsEditorTarget : TargetRules
 	public IntegrationTestsEditorTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		CppStandard = CppStandardVersion.Cpp20;
+#if UE_5_8_OR_LATER
 		DefaultBuildSettings = BuildSettingsVersion.V8;
+#else
+		DefaultBuildSettings = BuildSettingsVersion.V6;
+#endif
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 	}

--- a/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
+++ b/IntegrationTests/Source/IntegrationTestsEditor.Target.cs
@@ -8,7 +8,8 @@ public class IntegrationTestsEditorTarget : TargetRules
 	public IntegrationTestsEditorTarget( TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
-		DefaultBuildSettings = BuildSettingsVersion.V6;
+		CppStandard = CppStandardVersion.Cpp20;
+		DefaultBuildSettings = BuildSettingsVersion.V8;
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 		ExtraModuleNames.AddRange( new string[] { "IntegrationTests" } );
 	}

--- a/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
+++ b/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
@@ -21,6 +21,7 @@ public class NakamaBlueprints : ModuleRules
 	public NakamaBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		CppStandard = CppStandardVersion.Cpp20;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
+++ b/Nakama/Source/NakamaBlueprints/NakamaBlueprints.Build.cs
@@ -21,7 +21,9 @@ public class NakamaBlueprints : ModuleRules
 	public NakamaBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_8_OR_LATER
 		CppStandard = CppStandardVersion.Cpp20;
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaTests/NakamaTests.Build.cs
+++ b/Nakama/Source/NakamaTests/NakamaTests.Build.cs
@@ -21,6 +21,7 @@ public class NakamaTests : ModuleRules
 	public NakamaTests(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		CppStandard = CppStandardVersion.Cpp20;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaTests/NakamaTests.Build.cs
+++ b/Nakama/Source/NakamaTests/NakamaTests.Build.cs
@@ -21,7 +21,9 @@ public class NakamaTests : ModuleRules
 	public NakamaTests(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_8_OR_LATER
 		CppStandard = CppStandardVersion.Cpp20;
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaTests/Private/Tests/Realtime/Test_Tournament.cpp
+++ b/Nakama/Source/NakamaTests/Private/Tests/Realtime/Test_Tournament.cpp
@@ -38,19 +38,19 @@ inline bool Tournament::RunTest(const FString& Parameters)
 			// Create a JSON object and add properties to it
 			TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 
-			JsonObject->SetBoolField("authoritative", true);
-			JsonObject->SetStringField("sort_order", "desc");
-			JsonObject->SetStringField("operator", Operator);
-			JsonObject->SetNumberField("duration", Duration);
-			JsonObject->SetStringField("reset_schedule", ResetSchedule);
-			JsonObject->SetStringField("title", "Daily Dash");
-			JsonObject->SetStringField("description", "Dash past your opponents for high scores and big rewards!");
-			JsonObject->SetNumberField("category", 1);
-			JsonObject->SetNumberField("start_time", StartTime);
-			JsonObject->SetNumberField("end_time", EndTime);
-			JsonObject->SetNumberField("max_size", MaxSize);
-			JsonObject->SetNumberField("max_num_score", MaxNumScore);
-			JsonObject->SetBoolField("join_required", JoinRequired);
+			JsonObject->SetBoolField(TEXT("authoritative"), true);
+			JsonObject->SetStringField(TEXT("sort_order"), "desc");
+			JsonObject->SetStringField(TEXT("operator"), Operator);
+			JsonObject->SetNumberField(TEXT("duration"), Duration);
+			JsonObject->SetStringField(TEXT("reset_schedule"), ResetSchedule);
+			JsonObject->SetStringField(TEXT("title"), "Daily Dash");
+			JsonObject->SetStringField(TEXT("description"), "Dash past your opponents for high scores and big rewards!");
+			JsonObject->SetNumberField(TEXT("category"), 1);
+			JsonObject->SetNumberField(TEXT("start_time"), StartTime);
+			JsonObject->SetNumberField(TEXT("end_time"), EndTime);
+			JsonObject->SetNumberField(TEXT("max_size"), MaxSize);
+			JsonObject->SetNumberField(TEXT("max_num_score"), MaxNumScore);
+			JsonObject->SetBoolField(TEXT("join_required"), JoinRequired);
 
 			// Convert the JSON object to a string
 			FString JsonString;

--- a/Nakama/Source/NakamaTests/Private/Tests/Test_Errors.cpp
+++ b/Nakama/Source/NakamaTests/Private/Tests/Test_Errors.cpp
@@ -78,7 +78,7 @@ inline bool ErrorInvalidArgument::RunTest(const FString& Parameters)
 	// Define error callback
 	auto errorCallback = [&](const FNakamaError& Error)
 	{
-		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), Error.Code );
+		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), static_cast<int>(Error.Code));
 		TestTrue("Invalid Argument Test Passed", Error.Code == ENakamaErrorCode::InvalidArgument); 
 		StopTest();
 	};
@@ -115,7 +115,7 @@ inline bool ErrorInvalidArgument2::RunTest(const FString& Parameters)
 	// Define error callback
 	auto errorCallback = [&](const FNakamaError& Error)
 	{
-		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), Error.Code );
+		UE_LOG( LogTemp, Warning, TEXT("Error Code: %d"), static_cast<int>(Error.Code));
 		TestTrue("Invalid Argument 2 Test Passed", Error.Code == ENakamaErrorCode::InvalidArgument); 
 		StopTest();
 	};

--- a/Nakama/Source/NakamaTests/Private/Tests/Test_Storage.cpp
+++ b/Nakama/Source/NakamaTests/Private/Tests/Test_Storage.cpp
@@ -35,7 +35,7 @@ inline bool WriteStorageInvalidArgument::RunTest(const FString& Parameters)
 		auto errorCallback = [this](const FNakamaError& Error)
 		{
 			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorMessage: %s"), *Error.Message);
-			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorCode: %d"), Error.Code);
+			UE_LOG(LogTemp, Display, TEXT("WriteStorageInvalidArgument. ErrorCode: %d"), static_cast<int>(Error.Code));
 			TestTrue("Write Storage Invalid Argument Passed.", Error.Code == ENakamaErrorCode::InvalidArgument);
 			StopTest();
 		};

--- a/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
+++ b/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
@@ -22,6 +22,7 @@ public class NakamaUnreal : ModuleRules
 	public NakamaUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		CppStandard = CppStandardVersion.Cpp20;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
+++ b/Nakama/Source/NakamaUnreal/NakamaUnreal.Build.cs
@@ -22,7 +22,9 @@ public class NakamaUnreal : ModuleRules
 	public NakamaUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_8_OR_LATER
 		CppStandard = CppStandardVersion.Cpp20;
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Nakama/Source/NakamaUnreal/Private/NakamaAccountDevice.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaAccountDevice.cpp
@@ -38,7 +38,7 @@ FNakamaAccountDevice::FNakamaAccountDevice(const TSharedPtr<FJsonObject> JsonObj
 
 			for (const auto& Entry : (*VarsJsonObject)->Values)
 			{
-				FString Key = Entry.Key;
+				FString Key{Entry.Key};
 				FString Value = Entry.Value->AsString();
 
 				Vars.Add(Key, Value);

--- a/Nakama/Source/NakamaUnreal/Private/NakamaMatchTypes.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaMatchTypes.cpp
@@ -35,7 +35,7 @@ FNakamaMatchmakerUser::FNakamaMatchmakerUser(const TSharedPtr<FJsonObject> JsonO
 		{
 			for (const auto& Entry : (*StringPropertiesObject)->Values)
 			{
-				StringProperties.Add(Entry.Key, Entry.Value->AsString());
+				StringProperties.Emplace(Entry.Key, Entry.Value->AsString());
 			}
 		}
 
@@ -44,7 +44,7 @@ FNakamaMatchmakerUser::FNakamaMatchmakerUser(const TSharedPtr<FJsonObject> JsonO
 		{
 			for (const auto& Entry : (*NumericPropertiesObject)->Values)
 			{
-				NumericProperties.Add(Entry.Key, Entry.Value->AsNumber());
+				NumericProperties.Emplace(Entry.Key, Entry.Value->AsNumber());
 			}
 		}
 	}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaRtError.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaRtError.cpp
@@ -41,7 +41,7 @@ FNakamaRtError::FNakamaRtError(const FString& JsonString)
 		{
 			for (auto& Pair : (*ContextJsonObject)->Values)
 			{
-				Context.Add(Pair.Key, Pair.Value->AsString());
+				Context.Emplace(Pair.Key, Pair.Value->AsString());
 			}
 		}
 	}

--- a/Nakama/Source/NakamaUnreal/Private/NakamaSession.cpp
+++ b/Nakama/Source/NakamaUnreal/Private/NakamaSession.cpp
@@ -62,7 +62,7 @@ UNakamaSession* UNakamaSession::SetupSession(const FString& AuthResponse)
                 const TSharedPtr<FJsonObject>& VarsJson = PayloadJson->GetObjectField(TEXT("vrs"));
                 for (const auto& Entry : VarsJson->Values)
                 {
-                    FString Key = Entry.Key;
+                    FString Key{Entry.Key};
                     FString Value = Entry.Value->AsString();
 					ResultSession->SessionData.Variables.Add(Key, Value);
 					ResultSession->_Variables.Add(Key, Value);

--- a/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
+++ b/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
@@ -21,6 +21,7 @@ public class SatoriBlueprints : ModuleRules
 	public SatoriBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		CppStandard = CppStandardVersion.Cpp20;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
+++ b/Satori/Source/SatoriBlueprints/SatoriBlueprints.Build.cs
@@ -21,7 +21,9 @@ public class SatoriBlueprints : ModuleRules
 	public SatoriBlueprints(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_8_OR_LATER
 		CppStandard = CppStandardVersion.Cpp20;
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
+++ b/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
@@ -22,7 +22,9 @@ public class SatoriUnreal : ModuleRules
 	public SatoriUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+#if UE_5_8_OR_LATER
 		CppStandard = CppStandardVersion.Cpp20;
+#endif
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
+++ b/Satori/Source/SatoriUnreal/SatoriUnreal.Build.cs
@@ -22,6 +22,7 @@ public class SatoriUnreal : ModuleRules
 	public SatoriUnreal(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		CppStandard = CppStandardVersion.Cpp20;
 
 		PublicIncludePaths.AddRange(
 			new string[] {


### PR DESCRIPTION
This is a cleaner approach to add UE-5.8 compatibility than https://github.com/heroiclabs/nakama-unreal/pull/181. I do not introduce any version-specific code, but simply use API that is available in both 5.8 and earlier versions.

Tested compilation against UE-5.6 and UE-5.8.